### PR TITLE
style: update grid layout for links-grid component

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -146,7 +146,7 @@ main::-webkit-scrollbar {
 
 .links-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  grid-template-columns: repeat(4, 1fr);
   gap: 12px;
   padding: 16px
 }
@@ -325,7 +325,7 @@ button:hover {
   }
 
   .links-grid {
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    grid-template-columns: repeat(3, 1fr);
     gap: 8px;
     padding: 12px
   }
@@ -339,3 +339,9 @@ button:hover {
     height: 40px
   }
 }
+
+@media (max-width: 480px) {
+  .links-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+ }


### PR DESCRIPTION
Adjusts the grid layout of the links-grid component to use fixed 
column counts better responsiveness. the desktop layout 
to four columns and the mobile layout to two columns, improving 
visual consistency and usability across different screen sizes.