### PR TITLE
style: align link items to the start in styles.css

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -154,7 +154,7 @@ main::-webkit-scrollbar {
 .link-item {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   padding: 16px;
   border: 1px solid var(--border-color);
   border-radius: 8px;


### PR DESCRIPTION
Adjusts the alignment of link items from center to flex-start. This 
change improves the layout and visual consistency of the link items 
within the main container.